### PR TITLE
Ignore commands

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -5,3 +5,5 @@
   flows:
     - your_company/your_flow
   bot_nick: "Bot"
+  ignore_commands:
+    - strings matching command files

--- a/config.yml.example
+++ b/config.yml.example
@@ -4,24 +4,4 @@
   api_token: 'xxx'
   flows:
     - your_company/your_flow
-  em_port: 6000
   bot_nick: "Bot"
-  live_id: "xxxx"
-  poke_url: ""
-  pivotal_username: "cool@mail.com"
-  pivotal_password: "secret"
-  instagram_id: xxx
-  instagram_secret: xxx
-  spotify_appkey: spotify_appkey.key
-  spotify_username: 'xxx'
-  spotify_password: 'yyy'
-  tumblr_consumer_key: "xxxx"
-  tumblr_consumer_secret: "xxxx"
-  tumblr_oauth_token: 'xxxx'
-  tumblr_oauth_token_secret: 'xxxx'
-  tumblr_url: "tumblr.tumblr.com"
-  github_token: 'xxxx'
-  github_user: 'mynewsdesk'
-  semaphore:
-    hash_id: 'yyyy'
-    auth_token: 'yyyy'

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -3,6 +3,13 @@ require 'yaml'
 class Flower::Config
   CONFIG = YAML.load File.read(ENV.fetch("CONFIG") {"config.yml"})
 
+  def self.ignore_command?(file_path)
+    return unless CONFIG["ignore_commands"]
+    CONFIG["ignore_commands"].any? do |pattern|
+      file_path.include?(pattern)
+    end
+  end
+
   def self.method_missing(sym, *args, &block)
     CONFIG[sym.to_s]
   end

--- a/lib/flower.rb
+++ b/lib/flower.rb
@@ -19,7 +19,10 @@ class Flower
   LISTENERS = {} # We are going to load available monitors in here
 
   Dir.glob("lib/commands/**/*.rb").each do |file|
-    next if ENV['SKIP_SPOTIFY'] && file[/spotify/]
+    if Config.ignore_command?(file)
+      puts "*** ignoring #{file}"
+      next
+    end
     require File.expand_path(File.join(File.dirname(__FILE__), "..", file))
   end
 


### PR DESCRIPTION
Skip loading of commands based on a list in ´config.yml´

Makes it a lot easier to keep forks up to date since there's no need to remove unwanted commands anymore, just add it to the config file:
```yaml
ignore_commands:
  - lagg_ut
```
fixes #9 